### PR TITLE
Fix obsolete ocamlswitch.txt URL in Dockerfile

### DIFF
--- a/docker/build-fact/Dockerfile
+++ b/docker/build-fact/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get -y install apt-transport-https ca-certificates curl gnupg2 software-
 USER ${USER}
 RUN echo "export PATH=/usr/lib/llvm-6.0/bin/:$PATH" | tee -a /home/docker/.profile
 RUN opam init --compiler=4.06.0 
-RUN cd /home/docker/ && wget https://raw.githubusercontent.com/PLSysSec/FaCT/rewrite/ocamlswitch.txt && opam switch import ocamlswitch.txt && rm ocamlswitch.txt
+RUN cd /home/docker/ && wget https://raw.githubusercontent.com/PLSysSec/FaCT/master/ocamlswitch.txt && opam switch import ocamlswitch.txt && rm ocamlswitch.txt
 RUN echo "export LD_LIBRARY_PATH=$HOME/.opam/4.06.0/lib/z3" | tee -a /home/docker/.profile 
 RUN mkdir /home/docker/FaCT
 


### PR DESCRIPTION
`docker/build-fact/Dockerfile` references an `ocamlswitch.txt` in a branch that no longer exists on the FaCT repo. This PR changes the URL to refer to `master`.