### PR TITLE
Ensure compatibility with core ≥ 0.12

### DIFF
--- a/src/fact.ml
+++ b/src/fact.ml
@@ -125,7 +125,7 @@ let compile_command =
       flag "-shared" no_arg ~doc:shared_opt_doc +>
       flag "-no-inline-asm" no_arg ~doc:no_inline_asm_doc +>
       flag "-addl" (listed string) ~doc:addl_opts_doc +>
-      anon (sequence ("filename" %: file)))
+      anon (sequence ("filename" %: string)))
     (fun
       out_file
       debug


### PR DESCRIPTION
Not really sure about this one, as I could not find a changelog saying that the `file` value is no longer there. Also it seems to work but some behavior ([bash autocompletion](https://ocaml.janestreet.com/ocaml-core/v0.11/doc/core/Core/Command/Spec/#val-file)?) might be lost.

The motivation is to make it easier to build FaCT today, with recent versions of OCaml libraries.